### PR TITLE
Add headers and cookies to request

### DIFF
--- a/simpleapi/request.py
+++ b/simpleapi/request.py
@@ -1,72 +1,20 @@
-import cgi
-import json
-from typing import Any, BinaryIO, TypedDict
+from typing import Any
 
-
-Environ = TypedDict(
-    "Environ",
-    {
-        "REQUEST_METHOD": str,
-        "SCRIPT_NAME": str,
-        "PATH_INFO": str,
-        "QUERY_STRING": str,
-        "CONTENT_TYPE": str,
-        "CONTENT_LENGTH": str,
-        "SERVER_NAME": str,
-        "SERVER_PORT": int,
-        "SERVER_PROTOCOL": str,
-        "HTTP_": list[str],
-        "wsgi.version": tuple[int, int],
-        "wsgi.url_scheme": str,
-        "wsgi.input": BinaryIO,
-        "wsgi.errors": BinaryIO,
-        "wsgi.multithread": bool,
-        "wsgi.multiprocess": bool,
-        "wsgi.run_once": bool,
-    },
-)
+from . import utils
 
 
 class Request:
     """HTTP Request"""
 
-    def __init__(self, environ: Environ) -> None:
+    def __init__(self, environ: utils.Environ) -> None:
         self.environ = environ
-        body = environ["wsgi.input"]
-        self.form: dict[str, bytes] = {}
-        if is_post_request(environ):
-            storage = cgi.FieldStorage(fp=body, environ=environ)  # type: ignore
-            self.body: dict[str, str | int | float | bool] = {}
-            for k in storage.keys():
-                self.form[k] = storage[k].value
-        else:
-            read_body = body.read()
-            self.body = json.loads(read_body) if read_body else {}
         self.method = environ["REQUEST_METHOD"]
-        self.query = parse_query_string(environ["QUERY_STRING"])
         self.path = environ["PATH_INFO"]
         self.extra: dict[str, Any] = {}
         self.params: dict[str, str] = {}
-
-
-def is_post_request(environ: Environ):
-    if environ["REQUEST_METHOD"].upper() != "POST":
-        return False
-    content_type = environ.get("CONTENT_TYPE", "application/x-www-form-urlencoded")
-    return content_type.startswith(
-        "application/x-www-form-urlencoded"
-    ) or content_type.startswith("multipart/form-data")
-
-
-def parse_query_string(qs: str) -> dict[str, str]:
-    # ? I have decided to save only one value instead of an array of values
-    if not qs:
-        return {}
-    qs_list = qs.split("&")
-    result: dict[str, str] = {}
-    for q in qs_list:
-        equal_index = q.index("=")
-        key = q[:equal_index]
-        value = q[equal_index + 1 :]
-        result[key] = value
-    return result
+        self.form: dict[str, bytes]
+        self.body: dict[str, str | int | float | bool | dict]
+        self.body, self.form = utils.parse_body(environ)
+        self.query = utils.parse_query_string(environ)
+        self.headers: dict[str, str] = utils.parse_headers(environ)
+        self.cookies: dict[str, str] = utils.parse_cookies(environ)

--- a/simpleapi/response.py
+++ b/simpleapi/response.py
@@ -41,23 +41,22 @@ class Response:
     def __init__(
         self,
         body: str | dict[str, Any] | list | bytes | ErrorMessage,
-        content_type: str,
+        content_type: str = "text/html; charset=UTF-8",
         headers: list[tuple[str, str]] | None = None,
         code: int = 200,
     ) -> None:
+        # ? If the developer should set the content-type using the content_type argument and not supply it again to the headers argument
         self.body: Any = body
         self.content_type: str = content_type
         self.headers: list[tuple[str, str]] = headers if headers else []
         self.headers.append(("content-type", content_type))
         self.code = code
-        # self.code: int = Field(default=200, ge=100, le=599)
-        # self.encoding: str = Field(default="utf-8")
 
     def set_header(self, header: str, value: str) -> None:
         self.headers.append((header, value))
 
-    def parse_body(self):
-        return self.body
+    def set_cookie(self, key: str, value: str):
+        self.set_header("Set-Cookie", f"{key}={value}")
 
 
 class WSGIResponse:

--- a/simpleapi/simpleapi.py
+++ b/simpleapi/simpleapi.py
@@ -4,11 +4,12 @@ import json
 from typing import Callable
 
 from .core import API
+from .custom_types import ComponentMiddleware, Middleware, RouteHandler, ViewFunction
 from .handler import handle_request
-from .request import Environ, Request
+from .request import Request
 from .response import ParsingErrorResponse, WSGIResponse
 from .router import Router
-from .custom_types import Middleware, ComponentMiddleware, RouteHandler, ViewFunction
+from .utils import Environ
 
 
 class SimpleAPI(API):

--- a/simpleapi/utils.py
+++ b/simpleapi/utils.py
@@ -1,0 +1,90 @@
+import cgi
+import json
+from typing import BinaryIO, TypedDict
+
+Environ = TypedDict(
+    "Environ",
+    {
+        "REQUEST_METHOD": str,
+        "SCRIPT_NAME": str,
+        "PATH_INFO": str,
+        "QUERY_STRING": str,
+        "CONTENT_TYPE": str,
+        "CONTENT_LENGTH": str,
+        "SERVER_NAME": str,
+        "SERVER_PORT": int,
+        "SERVER_PROTOCOL": str,
+        "HTTP_COOKIE": str,
+        "wsgi.version": tuple[int, int],
+        "wsgi.url_scheme": str,
+        "wsgi.input": BinaryIO,
+        "wsgi.errors": BinaryIO,
+        "wsgi.multithread": bool,
+        "wsgi.multiprocess": bool,
+        "wsgi.run_once": bool,
+    },
+)
+
+
+def is_form_data_request(environ: Environ) -> bool:
+    """Returns True of the request method is POST, False otherwise"""
+    if environ["REQUEST_METHOD"].upper() != "POST":
+        return False
+    content_type = environ.get("CONTENT_TYPE", "application/x-www-form-urlencoded")
+    return content_type.startswith(
+        "application/x-www-form-urlencoded"
+    ) or content_type.startswith("multipart/form-data")
+
+
+def parse_body(
+    environ: Environ,
+) -> tuple[dict[str, str | int | float | bool | dict], dict[str, bytes]]:
+    """Parses request body and form data"""
+    raw_body = environ["wsgi.input"]
+    body: dict[str, str | int | float | bool | dict] = {}
+    form: dict[str, bytes] = {}
+    if is_form_data_request(environ):
+        storage = cgi.FieldStorage(fp=raw_body, environ=environ)  # type: ignore
+        body = {}
+        for k in storage.keys():
+            form[k] = storage[k].value
+    else:
+        read_body = raw_body.read()
+        body = json.loads(read_body) if read_body else {}
+    return body, form
+
+
+def parse_query_string(environ: Environ) -> dict[str, str]:
+    """Parses query parameters from a query string and returns a dict"""
+    # ? I have decided to save only one value instead of an array of values
+    if not environ["QUERY_STRING"]:
+        return {}
+    return {
+        k: v
+        for [k, v] in [query.split("=") for query in environ["QUERY_STRING"].split("&")]
+    }
+
+
+def parse_cookies(environ: Environ) -> dict[str, str]:
+    """Parses cookies from a cookie string and returns a dict of cookies, with keys as lowercase"""
+    # God, I love list/dict/set comprehension!
+    return (
+        {
+            k: v
+            for [k, v] in [
+                cookie.split("=")
+                for cookie in environ["HTTP_COOKIE"].replace(" ", "").split(";")
+            ]
+        }
+        if "HTTP_COOKIE" in environ.keys()
+        else {}
+    )
+
+
+def parse_headers(environ: Environ) -> dict[str, str]:
+    """Parses headers from a request and returns a dict of headers"""
+    headers: dict[str, str] = {}
+    for k, v in environ.items():
+        if k.startswith("HTTP_"):
+            headers[k.strip("HTTP_").lower()] = v  # type: ignore
+    return headers

--- a/tests/app.py
+++ b/tests/app.py
@@ -26,15 +26,11 @@ app = SimpleAPI(middleware=[global_middleware])
 @app.get("/set-cookie")
 def set_cookies(request: Request):
     """Sets cookies"""
-    return JSONResponse(
-        body=request.cookies,
-        headers=[
-            ("header1", "value1"),
-            ("Set-Cookie", "key1=value1; Path=/"),
-            ("Set-Cookie", "key2=value2; Path=/"),
-            ("Set-Cookie", "key3=value3;"),
-        ],
-    )
+    res = JSONResponse(body=request.cookies, headers=[("header1", "value1")])
+    res.set_cookie("key1", "value1")
+    res.set_cookie("key2", "value2")
+    res.set_cookie("key3", "value3")
+    return res
 
 
 @app.get("/set-headers")

--- a/tests/app.py
+++ b/tests/app.py
@@ -23,6 +23,29 @@ def always_reject_middleware(request: Request):
 app = SimpleAPI(middleware=[global_middleware])
 
 
+@app.get("/set-cookie")
+def set_cookies(request: Request):
+    """Sets cookies"""
+    return JSONResponse(
+        body=request.cookies,
+        headers=[
+            ("header1", "value1"),
+            ("Set-Cookie", "key1=value1; Path=/"),
+            ("Set-Cookie", "key2=value2; Path=/"),
+            ("Set-Cookie", "key3=value3;"),
+        ],
+    )
+
+
+@app.get("/set-headers")
+def set_headers(request: Request):
+    """Sets headers"""
+    return JSONResponse(
+        body=request.headers,
+        headers=[("header1", "value1"), ("header2", "value2"), ("header3", "value3")],
+    )
+
+
 @app.get("/test1/{test1}")
 def aa(request: Request):
     return request.params
@@ -60,7 +83,7 @@ items: list[Item] = []
 
 
 @app.get("/hello")
-def hello():
+def hello(request: Request):
     """Test hello world"""
     return "Hello, world!"
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -169,3 +169,45 @@ def test_not_found():
     assert not response.ok
     assert response.status_code == 404
     assert response.json() == {"errors": [{"loc": ["request"], "msg": "404 Not Found"}]}
+
+
+def test_set_cookies():
+    response = requests.get("http://localhost:8000/set-cookie")
+    assert response.ok
+    assert response.cookies.items() == [
+        ("key1", "value1"),
+        ("key2", "value2"),
+        ("key3", "value3"),
+    ]
+
+
+def test_reading_cookies():
+    cookies = {"name": "adhom", "age": "23"}
+    response = requests.get("http://localhost:8000/set-cookie", cookies=cookies)
+    assert response.ok
+    assert response.json() == cookies
+
+
+def test_set_headers():
+    response = requests.get("http://localhost:8000/set-headers")
+    assert response.ok
+    headers = [
+        ("header1", "value1"),
+        ("header2", "value2"),
+        ("header3", "value3"),
+    ]
+    for k, v in headers:
+        assert k in response.headers.keys()
+        assert v in response.headers.values()
+        assert response.headers[k] == v
+
+
+def test_reading_headers():
+    headers = {"name": "adhom", "age": "23"}
+    response = requests.get("http://localhost:8000/set-headers", headers=headers)
+    assert response.ok
+    json_response = response.json()
+    for k, v in headers.items():
+        assert k in json_response.keys()
+        assert v in json_response.values()
+        assert json_response[k] == v


### PR DESCRIPTION
This pull request:
1. Refactors the code in request.py into separate parsing helper functions in their own file called utils.py
2. Adds headers and cookies to the Request class
3. Adds set_cookie method for Response class
4. Sets the default response content-type to text/html