### PR TITLE
fix(validation): Fix return type hint validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "simplestapi"
-version = "0.1.4"
+version = "0.1.5"
 description = "SimpleAPI is a minimalistic, unopinionated web framework for Python, inspired by FastAPI & Flask"
 authors = ["Adham Salama <adham.salama@zohomail.com>"]
 license = "MIT"

--- a/simpleapi/__init__.py
+++ b/simpleapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.2"
+__version__ = "0.1.5"
 
 from .custom_types import RouteHandler, ViewFunction, Middleware, Query
 from .request import Request

--- a/simpleapi/handler.py
+++ b/simpleapi/handler.py
@@ -51,6 +51,10 @@ def handle_request(
                 return middleware_response
 
             handler_type_hints = get_type_hints(handler["handler"])
+            # Remove return type hint as we don't need it because it had caused
+            # a validation error for any handler function that had a return type hint
+            if "return" in handler_type_hints:
+                del handler_type_hints["return"]
             dependency_injection: dict[str, Any] = {}
             for k, v in handler_type_hints.items():
                 if v == Request:

--- a/tests/app.py
+++ b/tests/app.py
@@ -24,7 +24,10 @@ app = SimpleAPI(middleware=[global_middleware])
 
 
 @app.get("/set-cookie")
-def set_cookies(request: Request):
+# Don't remove the return type hint
+# this catches the case where handler function
+# has return type hint which throw a validation error
+def set_cookies(request: Request) -> JSONResponse:
     """Sets cookies"""
     res = JSONResponse(body=request.cookies, headers=[("header1", "value1")])
     res.set_cookie("key1", "value1")


### PR DESCRIPTION
If a handler function had a return type hint, it would be included in ```handler_type_hints```, so the validation logic expected the request body to have a field named "return" that had a type of whatever the handler return type hint was.

This PR fixes this issue by deleting the return type hint from ```handler_type_hints```. 